### PR TITLE
Update placeholder reference comment

### DIFF
--- a/src/utils/fileParser.ts
+++ b/src/utils/fileParser.ts
@@ -51,10 +51,11 @@ export async function createPresentationFromFile(file: File): Promise<Presentati
           originalContent: slideContent,
           suggestedUpdate: suggestedContent,
           status: 'pending',
-          // Add relevant references based on the presentation content
+          // Placeholder citations generated from the slide title rather
+          // than a true analysis of the file contents
           sourceCitations: [
-            `Reference 1 for ${slideTitle} (2023)`,
-            `Reference 2 for ${slideTitle} (2022)`
+          `Reference 1 for ${slideTitle} (2023)`,
+          `Reference 2 for ${slideTitle} (2022)`
           ],
           // Add a reason for the update
           updateReason: `Updated with latest information and improved formatting for better clarity and audience engagement.`


### PR DESCRIPTION
## Summary
- clarify that generated slide references are placeholders derived from the slide title

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842a24b9234832c8a30d41f0fa57d47